### PR TITLE
move strapi-helper-plugin from dev dependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,10 @@
     "test": "npm run lint",
     "prepublishOnly": "npm run build"
   },
-  "dependencies": {},
-  "devDependencies": {
+  "dependencies": {
     "strapi-helper-plugin": "3.0.0-alpha.11.1"
+  },
+  "devDependencies": {
   },
   "author": {
     "email": "hi@strapi.io",


### PR DESCRIPTION
When following setup as described here:
https://github.com/strapi/strapi/blob/master/.github/CONTRIBUTING.md
the build was breaking. I had to do move this dependency out of devDependencies to fix it.